### PR TITLE
Added proxy method to toggle nagivation

### DIFF
--- a/R/calendar-proxy.R
+++ b/R/calendar-proxy.R
@@ -313,3 +313,27 @@ cal_proxy_toggle <- function(proxy, calendarId, toHide = TRUE) {
     toHide = isTRUE(toHide)
   )
 }
+
+#' @title Toggle navigation visibility
+#'
+#' @description This function allow to show or hide the calendar navigation.
+#'
+#' @param proxy A [calendar_proxy()] `htmlwidget` object.
+#' @param navigation Logical, show or hide the navigation.
+#'
+#' @return A `calendar_proxy` object.
+#' @export
+#'
+#' @family calendar proxy methods
+#'
+#' @example examples/cal-proxy-toggle.R
+cal_proxy_navigation <- function(proxy, navigation) {
+  if (is.character(proxy)) {
+    proxy <- calendar_proxy(proxy)
+  }
+  .call_proxy(
+    proxy = proxy,
+    name = "calendar-navigation",
+    navigation = isTRUE(navigation)
+  )
+}

--- a/srcjs/modules/proxy-calendar.js
+++ b/srcjs/modules/proxy-calendar.js
@@ -1,7 +1,7 @@
 import "widgets";
 import dayjs from "dayjs";
 import * as utils from "./utils";
-import { formatDateNav, getNavOptions, addNavigation } from "./calendar-utils";
+import { formatDateNav, getNavOptions } from "./calendar-utils";
 
 export function ProxyCalendar() {
   if (HTMLWidgets.shinyMode) {

--- a/srcjs/modules/proxy-calendar.js
+++ b/srcjs/modules/proxy-calendar.js
@@ -1,7 +1,7 @@
 import "widgets";
 import dayjs from "dayjs";
 import * as utils from "./utils";
-import { formatDateNav, getNavOptions } from "./calendar-utils";
+import { formatDateNav, getNavOptions, addNavigation } from "./calendar-utils";
 
 export function ProxyCalendar() {
   if (HTMLWidgets.shinyMode) {
@@ -103,6 +103,26 @@ export function ProxyCalendar() {
           var calendarId = obj.data.calendarId;
           for (let i = 0; i < calendarId.length; i += 1) {
             cal.setCalendarVisibility(calendarId[i], obj.data.toHide);
+          }
+        }
+      }
+    );
+    Shiny.addCustomMessageHandler(
+      "proxy-toastui-calendar-navigation",
+      function (obj) {
+        var cal = utils.getWidget(obj.id);
+        if (typeof cal != "undefined" && typeof obj.data != "undefined") {
+          if (typeof obj.data.navigation === "boolean") {
+            var nav = obj.data.navigation;
+            var menu = document.getElementById(obj.id + "_menu");
+            // turn on and does not exists
+            if (nav && menu !== null) {
+              menu.style.display = "block";
+            }
+            // turn off and exists
+            if (!nav && menu !== null){
+              menu.style.display = "none";
+            }
           }
         }
       }

--- a/srcjs/modules/proxy-calendar.js
+++ b/srcjs/modules/proxy-calendar.js
@@ -88,8 +88,10 @@ export function ProxyCalendar() {
       "proxy-toastui-calendar-options",
       function (obj) {
         var cal = utils.getWidget(obj.id);
-        if (typeof cal != "undefined") {
-          cal.setOptions(obj.data.options);
+        if (typeof cal != "undefined" && typeof obj.data != "undefined") {
+          if (typeof obj.data.options != "undefined") {
+            cal.setOptions(obj.data.options);
+          }
         }
       }
     );

--- a/srcjs/widgets/calendar.js
+++ b/srcjs/widgets/calendar.js
@@ -24,12 +24,6 @@ HTMLWidgets.widget({
       renderValue: function (x) {
         var menu = document.getElementById(el.id + "_menu");
 
-        if (!x.navigation) {
-          if (menu !== null) {
-            menu.parentNode.removeChild(menu);
-          }
-        }
-
         if (typeof cal !== "undefined") {
           cal.destroy();
           el.innerHTML = "";
@@ -44,10 +38,11 @@ HTMLWidgets.widget({
           cal.setDate(x.defaultDate);
         }
 
+        addNavigation(cal, el.id, x.navigationOptions);
+        navigationOptions = x.navigationOptions;
         // Navigation buttons
-        if (x.navigation) {
-          addNavigation(cal, el.id, x.navigationOptions);
-          navigationOptions = x.navigationOptions;
+        if (!x.navigation) {
+          menu.style.display = "none";
         }
 
         if (x.events.hasOwnProperty("beforeCreateSchedule")) {

--- a/srcjs/widgets/calendar.js
+++ b/srcjs/widgets/calendar.js
@@ -41,7 +41,9 @@ HTMLWidgets.widget({
         addNavigation(cal, el.id, x.navigationOptions);
         navigationOptions = x.navigationOptions;
         // Navigation buttons
-        if (!x.navigation) {
+        if (x.navigation) {
+          menu.style.display = "block";
+        } else {
           menu.style.display = "none";
         }
 


### PR DESCRIPTION
Added a proxy method to turn on and off the navigation visibility. I had to change the "core" mechanic of the nav display. It is now always rendered and only shown/hidden using CSS. I hope this is ok:)

I also added a small sanity check into "proxy-toastui-calendar-options" listener.

Fixing issue #31 
